### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/common/workspace/common-java/pom.xml
+++ b/common/workspace/common-java/pom.xml
@@ -24,7 +24,7 @@
 		<ognl.version>2.6.7</ognl.version>
 		<hsqldb.version>1.8.0.7</hsqldb.version>
 		<commons-dbcp.version>1.2.2</commons-dbcp.version>
-		<commons-collection.version>3.2.1</commons-collection.version>
+		<commons-collection.version>3.2.2</commons-collection.version>
 		<commons-beanutils.version>1.7.0</commons-beanutils.version>
 		<slf4j.version>1.4.2</slf4j.version>
 		<log4j.version>1.2.15</log4j.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
